### PR TITLE
Progress change notification event

### DIFF
--- a/src/multi-step-form.js
+++ b/src/multi-step-form.js
@@ -175,6 +175,8 @@
                         else if (i === index) {
                             $(element).removeClass(msfCssClasses.stepComplete);
                             $(element).addClass(msfCssClasses.stepActive);
+                            var currentProgress = Math.round((i / form.steps.length)*100);
+                            $(document).trigger('msf:updateProgress', [currentProgress]);    // Trigger an event to notify the progress has changed
                         }
                         else {
                             $(element).removeClass(msfCssClasses.stepComplete);


### PR DESCRIPTION
Add an event trigger to notify the progress has changed, passing the current progress in percentage to the event handler as a custom parameter. This way, anyone can use this event to update their progress bar (I did not make it through the multi-step-form directly as I cannot know which implementation of progress bar they have so it will be to their discretion to do whatever they want with the event)

There could be a way to add a check for a data-progress-bar-target on the header element maybe and if present, assume they want the plugin to take care of its update, but I'm not sure if that would be a good idea.

Another option I would look at would be to let the user specify it's custom progress handler directly when initializing the plugin.