### PR TITLE
Second option for progress bar update (would fix #2)

### DIFF
--- a/src/multi-step-form.js
+++ b/src/multi-step-form.js
@@ -43,7 +43,8 @@
 
         var defaults = {
             activeIndex: 0,
-            validate: {}
+            validate: {},
+            progressHandler: undefined
         };
 
         var settings = $.extend({}, defaults, options);
@@ -175,6 +176,13 @@
                         else if (i === index) {
                             $(element).removeClass(msfCssClasses.stepComplete);
                             $(element).addClass(msfCssClasses.stepActive);
+                            var currentProgress = Math.round((i / form.steps.length)*100);
+                            if (typeof settings.progressHandler =='function') {
+                                settings.progressHandler.call(this, currentProgress);           // Call the specified progress update handler
+                            }
+                            else {
+                                $(document).trigger('msf:updateProgress', [currentProgress]);   // Trigger an event to notify the progress has changed
+                            }
                         }
                         else {
                             $(element).removeClass(msfCssClasses.stepComplete);


### PR DESCRIPTION
This option adds the possibility for the user to specify its own handler for the progress update event. If none was specified, we trigger the custom plugin event, else we call the specified function, still passing the current progress percentage as a parameter. 

Usage example for initialization: 
```
$(".msf:first").multiStepForm(
    {
        progressHandler: function (progressValue) 
        {
            // This is an example for bootstrap 4 progress bar 
            $progressBar.attr('aria-valuenow', progressValue + '%').css('width', progressValue + '%');
        }
    } 
);
```