### PR TITLE
Update dependencies and add package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "multi-step-form-js",
+  "version": "0.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
+    "jquery-validation": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.17.0.tgz",
+      "integrity": "sha512-XddiAwhGdWhcIJ+W3ri3KG8uTPMua4TPYuUIC8/E7lOyqdScG5xHuy9YishlKc0c/lIQai77EX7hxMdTSYCEjA==",
+      "requires": {
+        "jquery": "3.3.1"
+      }
+    },
+    "jquery-validation-unobtrusive": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/jquery-validation-unobtrusive/-/jquery-validation-unobtrusive-3.2.10.tgz",
+      "integrity": "sha512-z9ZBP/HslaGNKzFSpfLNJoFm2iqPJfE6CKM0H5e9LmKnYTFxErvCFQZomOLiTmLmZi8Wi/otW38cEXExVDha0w==",
+      "requires": {
+        "jquery": "3.3.1",
+        "jquery-validation": "1.17.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-step-form-js",
- "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Multi Step Form with jQuery Validation",
   "main": "index.js",
   "keywords": [
@@ -20,16 +20,15 @@
     "type": "git",
     "url": "https://github.com/mgildea/Multi-Step-Form-Js.git"
   },
- "author": "Matthew Gildea <mattgildea@hotmail.com> (https://github.com/mgildea)",
+  "author": "Matthew Gildea <mattgildea@hotmail.com> (https://github.com/mgildea)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mgildea/Multi-Step-Form-Js/issues"
   },
   "homepage": "https://github.com/mgildea/Multi-Step-Form-Js",
   "dependencies": {
-    "jquery": "^2.2.0",
-    "jquery-validation":"^1.16",
-    "jquery-validation-unobtrusive": "3.2.6"
+    "jquery": "^3.3.1",
+    "jquery-validation": "^1.17.0",
+    "jquery-validation-unobtrusive": "3.2.10"
   }
-   
 }


### PR DESCRIPTION
Update dependencies to latest versions to remove npm security audit critical errors (because of XSS vulnerability)

Fixes #18 